### PR TITLE
feat: Release pyroscope to edge risk track

### DIFF
--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -12,3 +12,4 @@ jobs:
     secrets: inherit
     with:
       rock-name: pyroscope
+      risk-track: edge


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
After https://github.com/lucabello/noctua/pull/12 and https://github.com/canonical/observability/pull/358 we're now able to release OCI factory images to different risk tracks. As [agreed in the oci-factory discussion](https://github.com/canonical/oci-factory/pull/489#issuecomment-3024497972), pyroscope should be released to `edge`.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add the `risk-track` input to our workflow trigger.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
