### PR TITLE
fix: Pass its version correctly to pyroscope

### DIFF
--- a/1.14.1/rockcraft.yaml
+++ b/1.14.1/rockcraft.yaml
@@ -32,8 +32,11 @@ parts:
       npm install --global yarn
       yarn --frozen-lockfile
       yarn build
-      GOAMD64=v2 CGO_ENABLED=0 go build -tags "netgo embedassets" -gcflags="all=-N -l" -ldflags "-extldflags \"-static\" -X main.Version=${CRAFT_PROJECT_VERSION}" -o $CRAFT_PART_INSTALL/bin/pyroscope ./cmd/pyroscope
-      GOAMD64=v2 CGO_ENABLED=0 go build -gcflags="all=-N -l" -ldflags "-extldflags \"-static\" -X main.Version=${CRAFT_PROJECT_VERSION}" -o $CRAFT_PART_INSTALL/bin/profilecli ./cmd/profilecli
+      GIT_REVISION=`git rev-parse HEAD`
+      GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+      BUILD_DATE=`date +"%Y-%m-%dT%H:%M:%S%z"`
+      GOAMD64=v2 CGO_ENABLED=0 go build -tags "netgo embedassets" -gcflags="all=-N -l" -ldflags "-extldflags \"-static\" -X github.com/grafana/pyroscope/pkg/util/build.Version=${CRAFT_PROJECT_VERSION} -X github.com/grafana/pyroscope/pkg/util/build.Branch=${GIT_BRANCH} -X github.com/grafana/pyroscope/pkg/util/build.Revision=${GIT_REVISION} -X github.com/grafana/pyroscope/pkg/util/build.BuildDate=${BUILD_DATE}" -o $CRAFT_PART_INSTALL/bin/pyroscope ./cmd/pyroscope
+      GOAMD64=v2 CGO_ENABLED=0 go build -gcflags="all=-N -l" -ldflags "-extldflags \"-static\" -X github.com/grafana/pyroscope/pkg/util/build.Version=${CRAFT_PROJECT_VERSION} -X github.com/grafana/pyroscope/pkg/util/build.Branch=${GIT_BRANCH} -X github.com/grafana/pyroscope/pkg/util/build.Revision=${GIT_REVISION} -X github.com/grafana/pyroscope/pkg/util/build.BuildDate=${BUILD_DATE}" -o $CRAFT_PART_INSTALL/bin/profilecli ./cmd/profilecli
     stage:
       - bin/pyroscope
       - bin/profilecli


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Pyroscope rock was passed a wrong name of the Version parameter, as seen here: https://github.com/grafana/pyroscope/blob/c67b86ef738e7df3ea71c60598553d439345b305/Makefile#L39-L40


## Solution
<!-- A summary of the solution addressing the above issue -->
Pass the correct parameter, plus other params that were passed in the upstream Makefile. Fixes #6.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`just pack 1.14.1 && just run 1.14.1`, then `/bin/pyroscope --version`. See the following:

<img width="1077" height="277" alt="Screenshot from 2025-09-02 11-39-13" src="https://github.com/user-attachments/assets/ab91a424-db7d-4c80-a4e2-eaee46418b6d" />


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
