### PR TITLE
fix: bump vulnerable Go deps in the 2.2.0 rock

### DIFF
--- a/2.2.0/rockcraft.yaml
+++ b/2.2.0/rockcraft.yaml
@@ -36,6 +36,7 @@ parts:
       corepack yarn install --immutable
       corepack yarn build
       cd ..
+      go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1
       GIT_REVISION=`git rev-parse HEAD`
       GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
       BUILD_DATE=$(git log -1 --date=iso-strict --format=%cd)   # commit date => reproducible


### PR DESCRIPTION
Bumps `golang.org/x/text` v0.37.0 to v0.39.0 and `google.golang.org/grpc` v1.81.0 to
v1.82.1 during the build.

Upstream v2.2.0 pins both at versions with known HIGH advisories (`CVE-2026-56852` and
`GHSA-hrxh-6v49-42gf`), which fails the OCI Factory vulnerability gate and is blocking
[oci-factory#1160](https://github.com/canonical/oci-factory/pull/1160). Both already have
fixed releases upstream, so picking them up seemed better than adding them to
`ignored-vulnerabilities`. Note they are not in the suppression list the 1.18.1 entry
carries, so restoring that list would not have fixed the gate on its own.

Verified locally with trivy 0.69.3 using the same flags OCI Factory runs: the stock build
exits 1 with 4 HIGH findings, with this change it exits 0 with none. `pyroscope --version`
still reports the same upstream revision, and a monolithic v2 run came up cleanly (raft,
memberlist, and profiles flushed to object storage) so the grpc bump does not disturb the
internal gRPC paths.

Can be dropped once upstream bumps these itself.
