### PR TITLE
feat: add 2.2 release line (pyroscope 2.2.1)

### DIFF
--- a/2.2/pyroscope.yaml
+++ b/2.2/pyroscope.yaml
@@ -1,0 +1,1 @@
+target: all

--- a/2.2/rockcraft.yaml
+++ b/2.2/rockcraft.yaml
@@ -1,0 +1,74 @@
+name: pyroscope
+summary: Pyroscope in a rock.
+description: "Pyroscope continuous profiling tool."
+version: "2.2.1"
+base: ubuntu@26.04
+license: AGPL-3.0
+services:
+  pyroscope:
+    command: /bin/pyroscope --config.file=/etc/pyroscope/pyroscope.yaml
+    override: replace
+    startup: enabled
+platforms:
+  amd64:
+parts:
+  pyroscope:
+    plugin: go
+    source: https://github.com/grafana/pyroscope
+    source-type: git
+    source-tag: "v2.2.1"
+    source-depth: 1
+    source-submodules: []
+    build-snaps:
+      - go/1.25/candidate
+      - node/24/stable # ui/ requires node >=24; 26.04 apt only has node 22
+    build-environment:
+      - BUILD_IN_CONTAINER: "false"
+    build-packages:
+      - libsystemd-dev
+      - libpango1.0-dev
+      - libcairo2-dev
+    override-build: |
+      # ui/ builds with yarn 4 via corepack; the node snap's bin isn't on PATH by default.
+      export PATH="/snap/node/current/bin:${PATH}"
+      export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+      cd ui
+      corepack yarn install --immutable
+      corepack yarn build
+      cd ..
+      GIT_REVISION=`git rev-parse HEAD`
+      GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+      BUILD_DATE=$(git log -1 --date=iso-strict --format=%cd)   # commit date => reproducible
+      VPREFIX=github.com/grafana/pyroscope/v2/pkg/util/build
+      GCFLAGS="all=-N -l"
+      LDFLAGS="-extldflags \"-static\" \
+        -X ${VPREFIX}.Version=${CRAFT_PROJECT_VERSION} \
+        -X ${VPREFIX}.Branch=${GIT_BRANCH} \
+        -X ${VPREFIX}.Revision=${GIT_REVISION} \
+        -X ${VPREFIX}.BuildDate=${BUILD_DATE}"
+      export GOAMD64=v2 CGO_ENABLED=0
+
+      go build -tags "netgo embedassets" -gcflags="${GCFLAGS}" -ldflags "${LDFLAGS}" -o $CRAFT_PART_INSTALL/bin/pyroscope ./cmd/pyroscope
+      go build -gcflags="${GCFLAGS}" -ldflags "${LDFLAGS}" -o $CRAFT_PART_INSTALL/bin/profilecli ./cmd/profilecli
+    stage:
+      - bin/pyroscope
+      - bin/profilecli
+  default-config:
+    plugin: dump
+    source: .
+    organize:
+      pyroscope.yaml: etc/pyroscope/pyroscope.yaml
+    stage:
+      - etc/pyroscope/pyroscope.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - pyroscope
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/2.2/spread/.extension
+++ b/2.2/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/2.2/spread/general/ready/task.yaml
+++ b/2.2/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/spread.yaml
+++ b/spread.yaml
@@ -12,7 +12,7 @@ suites:
     summary: General integration tests
     environment:
       # Goss environment
-      GOSS_OPTS: "--retry-timeout=60s"
+      GOSS_OPTS: "--retry-timeout=120s"
       GOSS_FILES_STRATEGY: cp
       DGOSS_TEMP_DIR: "$HOME"
 


### PR DESCRIPTION
Restores the 2.2 rock dropped in #60, as a `major.minor` folder. Needed for the Pyroscope v2 migration (canonical/oci-factory#1176).